### PR TITLE
fix: current version of esm is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "files": [
     "lib/"
   ],
+  "sideEffects": false,
   "scripts": {
     "prepublishOnly": "npm run tsc",
     "test": "npm run tsc && vitest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
-import { EmbeddingModel, ExecutionProvider, FlagEmbedding } from "./fastembed";
-export { EmbeddingModel, ExecutionProvider, FlagEmbedding };
+export {
+  EmbeddingModel,
+  ExecutionProvider,
+  FlagEmbedding,
+} from "./fastembed.js";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES2020",
     "module": "ES2020",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
The typescript build is not adding extensions when compiling. 
https://github.com/microsoft/TypeScript/issues/16577

It started to happen when the package.json got changed and nodejs is actually finding the esm import
```
"exports": {
    ".": {
      "import": {
        "types": "./lib/esm/index.d.ts",
        "default": "./lib/esm/index.js"
      },
      "require": {
        "types": "./lib/cjs/index.d.ts",
        "default": "./lib/cjs/index.js"
      }
    }
  },
```

I've added the extension, and it works as it should.

I've also updated the build configuration so that it does not transpile down to es5. It's node 18+ compatible

We're using it in https://github.com/mastra-ai/mastra and were experiencing this issue. Thank you for maintaining this package!
