### PR TITLE
fix: fake type module in esm lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "scripts": {
     "prepublishOnly": "npm run tsc",
     "test": "npm run tsc && vitest",
-    "tsc": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json"
+    "tsc": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
+    "posttsc": "echo '{\"type\": \"module\"}' > ./lib/esm/package.json"
   },
   "dependencies": {
     "@anush008/tokenizers": "^0.0.0",


### PR DESCRIPTION
Fixes a weird esm bug where import is not recognized as an ESM module. By adding a package.json with type module to the lib/esm folder it magically works.

This error seems to be fixed in node 22.10.0, but all lower versions get the error below

Erorr we are seeying:
```
node --input-type=module -e "import('fastembed').then(mod => console.log(mod))"
(node:54846) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
<myproject>/node_modules/fastembed/lib/esm/index.js:1
export { EmbeddingModel, ExecutionProvider, FlagEmbedding, } from "./fastembed.js";
^^^^^^

SyntaxError: Unexpected token 'export'
```
